### PR TITLE
Fixes for building on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Binaries.
-*.so
-
 # Objects.
 .scons-cache/
 *.os
@@ -11,7 +8,7 @@
 *.pyc
 
 # MacOS
-.DS_Store/
+.DS_Store
 
 # Editors
 .vscode/

--- a/SConstruct
+++ b/SConstruct
@@ -27,9 +27,9 @@ extension_name = Path(extension_path).stem
 #     print("Scons cache enabled... (path: '" + scons_cache_path + "')")
 
 # Create the library target (e.g. libexample.linux.debug.x86_64.so).
-if env["platform"] == "osx":
+if env["platform"] == "macos":
     library = env.SharedLibrary(
-        "{}/bin/lib{}.{}.{}.framework/{1}.{2}.{3}".format(
+        "{0}/bin/lib{1}.{2}.{3}.framework/{1}.{2}.{3}".format(
             addon_path,
             extension_name,
             env["platform"],

--- a/project/addons/example/bin/.gitignore
+++ b/project/addons/example/bin/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/project/addons/example/example.gdextension
+++ b/project/addons/example/example.gdextension
@@ -4,8 +4,8 @@ entry_symbol = "gdextension_init"
 
 [libraries]
 
-macos.debug = "bin/libexample.osx.debug.framework"
-macos.release = "bin/libexample.osx.release.framework"
+macos.debug = "bin/libexample.macos.debug.framework"
+macos.release = "bin/libexample.macos.release.framework"
 windows.debug.x86_64 = "bin/libexample.windows.debug.x86_64.dll"
 windows.release.x86_64 = "bin/libexample.windows.release.x86_64.dll"
 linux.debug.x86_64 = "bin/libexample.linux.debug.x86_64.so"


### PR DESCRIPTION
This PR fixes issues with building on macOS:

* `.DS_Store` is the name of a file, not the name of a folder.
* Rename `osx` to `macos`
* Change `.gitkeep` to a `.gitignore` that ignores the content of the bin folder.
* Fix string numbers not being consistent in SConstruct.
* ~~Update `godot-cpp`~~ See ebf94e6c63343e22eac3a3efc81788fe8550ddc9